### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/auto-complete-nxml.el
+++ b/auto-complete-nxml.el
@@ -5,6 +5,7 @@
 ;; Author: Hiroaki Otsu <ootsuhiroaki@gmail.com>
 ;; Keywords: completion, html, xml
 ;; URL: https://github.com/aki2o/auto-complete-nxml
+;; Package-Requires: ((auto-complete "1.4"))
 ;; Version: 0.3.1
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -207,7 +208,7 @@
             if (string-match "^\"" line)
             do (let* ((line (replace-regexp-in-string "^\"" "" line))
                       (line (replace-regexp-in-string "\"\\s-*~?\\s-*$" "" line))
-                      (line (replace-regexp-in-string ".$" "" line)) ;delete  
+                      (line (replace-regexp-in-string ".$" "" line)) ;delete 
                       (line (replace-regexp-in-string "^\\s-+" "" line))
                       (line (replace-regexp-in-string "\\s-+$" "" line)))
                  (when (not (string= line ""))


### PR DESCRIPTION
There's been a [request](https://github.com/milkypostman/melpa/pull/1034) to add `auto-complete-nxml` to MELPA, so I thought I'd send this quick fix. :-)

-Steve
